### PR TITLE
RIPE RPKI archive format changed (.xz) #14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 appdirs
 py-radix
 portion
+lzma
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 appdirs
 py-radix
 portion
-lzma
 

--- a/rov/__init__.py
+++ b/rov/__init__.py
@@ -66,11 +66,12 @@ DEFAULT_RPKI_URLS = [
         'https://rpki.gin.ntt.net/api/export.json'
         ]
 RPKI_ARCHIVE_URLS = [ 
-        'https://ftp.ripe.net/ripe/rpki/afrinic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
-        'https://ftp.ripe.net/ripe/rpki/apnic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
-        'https://ftp.ripe.net/ripe/rpki/arin.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
-        'https://ftp.ripe.net/ripe/rpki/lacnic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
-        'https://ftp.ripe.net/ripe/rpki/ripencc.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        'https://ftp.ripe.net/rpki/afrinic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        'https://ftp.ripe.net/rpki/apnic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        'https://ftp.ripe.net/rpki/arin.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        'https://ftp.ripe.net/rpki/lacnic.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        'https://ftp.ripe.net/rpki/ripencc.tal/{year:04d}/{month:02d}/{day:02d}/roas.csv.xz',
+        
         ]
 DEFAULT_DELEGATED_URLS = [ 
         'https://www.nro.net/wp-content/uploads/delegated-stats/nro-extended-stats'

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'appdirs',
         'py-radix',
         'portion',
+        'lzma'
     ],
     entry_points={'console_scripts':
             ['rov = rov.__main__:main']},

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md') as f:
     readme = f.read()
 
 setup(
-    version = '0.4.0',
+    version = '0.5.0',
     name = 'rov',
     author = 'Romain Fontugne',
     author_email = 'romain.fontugne@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     install_requires=[
         'appdirs',
         'py-radix',
-        'portion',
-        'lzma'
+        'portion'
     ],
     entry_points={'console_scripts':
             ['rov = rov.__main__:main']},


### PR DESCRIPTION
Updated the URLS OF RPKI_ARCHIVE_URLS and uncompressed it .

solving the issue of #14 



```cmd

PS C:\Users\RISHI\Desktop\route-origin-validator\rov> rov  8.8.8.0/24 15169 --rpki_archive 2024/01/12
Downloading: https://ftp.ripe.net/rpki/afrinic.tal/2024/01/12/roas.csv.xz
Downloading: https://ftp.ripe.net/rpki/apnic.tal/2024/01/12/roas.csv.xz
Downloading: https://ftp.ripe.net/rpki/arin.tal/2024/01/12/roas.csv.xz
Downloading: https://ftp.ripe.net/rpki/lacnic.tal/2024/01/12/roas.csv.xz
Downloading: https://ftp.ripe.net/rpki/ripencc.tal/2024/01/12/roas.csv.xz
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/delegated\nro-extended-stats
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/irr\+lacnic.db.gz
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/irr\lacnic.db.gz
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/rpki//2024/01/12\afrinic.csv
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/rpki//2024/01/12\apnic.csv
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/rpki//2024/01/12\arin.csv
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/rpki//2024/01/12\lacnic.csv
Loading: C:\Users\RISHI\AppData\Local\IHR\rov\Cache/db/rpki//2024/01/12\ripencc.csv
{
    "query": {
        "prefix": "8.8.8.0/24",
        "asn": 15169
    },
    "irr": {
        "status": "NotFound"
    },
    "rpki": {
        "status": "Valid",
        "prefix": "8.8.8.0/24",
        "maxLength": 24,
        "ta": "unknown",
        "startTime": "2023-12-29 17:14:18",
        "endTime": "2024-03-28 16:14:18",
        "uri": "rsync://rpki.arin.net/repository/arin-rpki-ta/5e4a23ea-e80a-403e-b08c-2171da2157d3/f60c9f32-a87c-4339-a2f3-6299a3b02e29/5e9328a9-e1d2-45d8-bdb5-eefe152994f9/d74ad38d-11d3-3c79-a22a-29626dd55bea.roa"
    },
    "delegated": {
        "prefix": {
            "status": "assigned",
            "prefix": "8.8.8.0/24",
            "date": "20231228",
            "registry": "arin",
            "country": "US"
        },
        "asn": {
            "status": "assigned",
            "registry": "arin"
        }
    }
}

```

I have only shown the output for  RPKI_ARCHIVE_URLS  didn't included the other URLS in the output

@romain-fontugne review my PR :-)